### PR TITLE
Local rotation

### DIFF
--- a/Gizmo/Gizmo/ComfyGizmo.cs
+++ b/Gizmo/Gizmo/ComfyGizmo.cs
@@ -247,13 +247,13 @@ namespace Gizmo {
       _gizmoRoot = Instantiate(_gizmoPrefab).transform;
 
       // ??? Something about quaternions.
-      _zGizmo = _gizmoRoot.Find("YRoot/ZRoot/XRoot/X");
+      _xGizmo = _gizmoRoot.Find("YRoot/ZRoot/XRoot/X");
       _yGizmo = _gizmoRoot.Find("YRoot/Y");
-      _xGizmo = _gizmoRoot.Find("YRoot/ZRoot/Z");
+      _zGizmo = _gizmoRoot.Find("YRoot/ZRoot/Z");
 
-      _zGizmoRoot = _gizmoRoot.Find("YRoot/ZRoot/XRoot");
+      _xGizmoRoot = _gizmoRoot.Find("YRoot/ZRoot/XRoot");
       _yGizmoRoot = _gizmoRoot.Find("YRoot");
-      _xGizmoRoot = _gizmoRoot.Find("YRoot/ZRoot");
+      _zGizmoRoot = _gizmoRoot.Find("YRoot/ZRoot");
 
       return _gizmoRoot.transform;
     }

--- a/Gizmo/Gizmo/ComfyGizmo.cs
+++ b/Gizmo/Gizmo/ComfyGizmo.cs
@@ -17,7 +17,7 @@ namespace Gizmo {
   public class ComfyGizmo : BaseUnityPlugin {
     public const string PluginGUID = "com.rolopogo.gizmo.comfy";
     public const string PluginName = "ComfyGizmo";
-    public const string PluginVersion = "1.4.1";
+    public const string PluginVersion = "1.5.0";
 
     static GameObject _gizmoPrefab = null;
     static Transform _gizmoRoot;

--- a/Gizmo/Gizmo/PluginConfig.cs
+++ b/Gizmo/Gizmo/PluginConfig.cs
@@ -10,8 +10,10 @@ namespace Gizmo {
     public static ConfigEntry<KeyboardShortcut> ZRotationKey;
     public static ConfigEntry<KeyboardShortcut> ResetRotationKey;
     public static ConfigEntry<KeyboardShortcut> ResetAllRotationKey;
+    public static ConfigEntry<KeyboardShortcut> ChangeRotationModeKey;
 
     public static ConfigEntry<bool> ShowGizmoPrefab;
+    public static ConfigEntry<bool> UseLocalFrame;
 
     public static void BindConfig(ConfigFile config) {
       SnapDivisions =
@@ -51,7 +53,16 @@ namespace Gizmo {
               KeyboardShortcut.Empty,
               "Press this key to reset _all axis_ rotations to zero rotation.");
 
+
+      ChangeRotationModeKey =
+          config.Bind(
+              "Keys",
+              "changeRotationMode",
+              new KeyboardShortcut(KeyCode.BackQuote),
+              "Press this key to reset _all axis_ rotations to zero rotation.");
+
       ShowGizmoPrefab = config.Bind("UI", "showGizmoPrefab", true, "Show the Gizmo prefab in placement mode.");
+      UseLocalFrame = config.Bind("RotationFrame", "useLocalFrame", false, "Use the local piece coordinate system for rotations.");
     }
   }
 }

--- a/Gizmo/Gizmo/PluginConfig.cs
+++ b/Gizmo/Gizmo/PluginConfig.cs
@@ -11,6 +11,7 @@ namespace Gizmo {
     public static ConfigEntry<KeyboardShortcut> ResetRotationKey;
     public static ConfigEntry<KeyboardShortcut> ResetAllRotationKey;
     public static ConfigEntry<KeyboardShortcut> ChangeRotationModeKey;
+    public static ConfigEntry<KeyboardShortcut> CopyPieceRotationKey;
 
     public static ConfigEntry<bool> ShowGizmoPrefab;
     public static ConfigEntry<bool> UseLocalFrame;
@@ -59,7 +60,14 @@ namespace Gizmo {
               "Keys",
               "changeRotationMode",
               new KeyboardShortcut(KeyCode.BackQuote),
-              "Press this key to reset _all axis_ rotations to zero rotation.");
+              "Press this key to toggle rotation modes.");
+
+      CopyPieceRotationKey =
+          config.Bind(
+              "Keys",
+              "copyPieceRotation",
+              KeyboardShortcut.Empty,
+              "Press this key to copy targeted piece's rotation.");
 
       ShowGizmoPrefab = config.Bind("UI", "showGizmoPrefab", true, "Show the Gizmo prefab in placement mode.");
       UseLocalFrame = config.Bind("RotationFrame", "useLocalFrame", false, "Use the local piece coordinate system for rotations.");

--- a/Gizmo/Gizmo/README.md
+++ b/Gizmo/Gizmo/README.md
@@ -26,6 +26,11 @@
   
 ## Changelog
 
+### 1.5.0
+  * Added alternate rotation method for using local frame coordinates.
+  * Added configuration option to rotate using local frame coordinates.
+  * Hot key added to toggle between default and local frame rotation modes. Default set to back quote.
+  
 ### 1.4.0
 
   * Create a new GameObject `ComfyGizmo` to maintain the current Quaternion rotation state.

--- a/Gizmo/Gizmo/manifest.json
+++ b/Gizmo/Gizmo/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Gizmo",
-  "version_number": "1.4.1",
+  "version_number": "1.5.0",
   "author": "ComfyMods",
   "website_url": "https://github.com/redseiko/ValheimMods/tree/main/Gizmo/Gizmo",
   "description": "Comfy-specific fork of Gizmo.",

--- a/Gizmo/Gizmo/manifest.json
+++ b/Gizmo/Gizmo/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Gizmo",
-  "version_number": "1.4.0",
+  "version_number": "1.4.1",
   "author": "ComfyMods",
   "website_url": "https://github.com/redseiko/ValheimMods/tree/main/Gizmo/Gizmo",
   "description": "Comfy-specific fork of Gizmo.",


### PR DESCRIPTION
Added ability to rotate around a piece's local frame. Toggle for switching between rotation modes added to config with default BackQuote. On mode switch rotation of piece will be restored to default. Added ability to change placement piece rotation to match rotation of targeted piece on key press. Default unbound. 