### PR TITLE
Copy rotation fix and more features

### DIFF
--- a/Gizmo/Gizmo/ComfyGizmo.cs
+++ b/Gizmo/Gizmo/ComfyGizmo.cs
@@ -245,9 +245,9 @@ namespace Gizmo {
         _gizmoRoot.rotation = targetQuaternion;
       } else {
         Vector3 eulerAngles = GetEulerAngles(target);
-        _xRot = (int)Math.Floor(eulerAngles.x/_snapAngle);
-        _yRot = (int)Math.Floor(eulerAngles.y / _snapAngle);
-        _zRot = (int)Math.Floor(eulerAngles.z / _snapAngle);
+        _xRot = (int)Math.Round(eulerAngles.x/_snapAngle);
+        _yRot = (int)Math.Round(eulerAngles.y / _snapAngle);
+        _zRot = (int)Math.Round(eulerAngles.z / _snapAngle);
         Rotate();
       }
     }

--- a/Gizmo/Gizmo/ComfyGizmo.cs
+++ b/Gizmo/Gizmo/ComfyGizmo.cs
@@ -34,6 +34,7 @@ namespace Gizmo {
     static Transform _comfyGizmoRoot;
 
     static Vector3 _eulerAngles;
+    static float _rotation;
 
     static bool _localFrame;
 
@@ -170,8 +171,7 @@ namespace Gizmo {
         if (!_localFrame) {
           Rotate();
         } else {
-          int direction = Math.Sign(Input.GetAxis("Mouse ScrollWheel"));
-          RotateLocalFrame(direction);
+          RotateLocalFrame();
         }
       }
     }
@@ -194,30 +194,30 @@ namespace Gizmo {
       RotateGizmoComponents(_eulerAngles);
     }
 
-    static void RotateLocalFrame(int direction) {
+    static void RotateLocalFrame() {
       if (Input.GetKey(ResetAllRotationKey.Value.MainKey)) {
         ResetRotationsLocalFrame();
         return;
       }
 
-      float rotation = direction * _snapAngle;
+      _rotation = 0f;
       Vector3 rotVector;
 
       if (Input.GetKey(XRotationKey.Value.MainKey)) {
         _xGizmo.localScale = Vector3.one * 1.5f;
         rotVector = Vector3.right;
-        HandleAxisInputLocalFrame(rotVector, _xGizmo);
+        HandleAxisInputLocalFrame(ref _rotation, rotVector, _xGizmo);
       } else if (Input.GetKey(ZRotationKey.Value.MainKey)) {
         _zGizmo.localScale = Vector3.one * 1.5f;
         rotVector = Vector3.forward;
-        HandleAxisInputLocalFrame(rotVector, _zGizmo);
+        HandleAxisInputLocalFrame(ref _rotation, rotVector, _zGizmo);
       } else {
         _yGizmo.localScale = Vector3.one * 1.5f;
         rotVector = Vector3.up;
-        HandleAxisInputLocalFrame(rotVector, _yGizmo);
+        HandleAxisInputLocalFrame(ref _rotation, rotVector, _yGizmo);
       }
 
-      RotateAxes(rotation, rotVector);
+      RotateAxes(_rotation, rotVector);
     }
 
     static void RotateAxes(float rotation, Vector3 rotVector) {
@@ -234,14 +234,13 @@ namespace Gizmo {
       return rotation;
     }
 
-    static void HandleAxisInputLocalFrame(Vector3 rotVector, Transform gizmo) {
+    static void HandleAxisInputLocalFrame(ref float rotation, Vector3 rotVector, Transform gizmo) {
       gizmo.localScale = Vector3.one * 1.5f;
+      rotation = Math.Sign(Input.GetAxis("Mouse ScrollWheel")) * _snapAngle;
 
       if (Input.GetKey(ResetRotationKey.Value.MainKey)) {
-        _comfyGizmo.transform.rotation = Quaternion.AngleAxis(0f, rotVector);
-        _xGizmoRoot.rotation = Quaternion.AngleAxis(0f, rotVector);
-        _yGizmoRoot.rotation = Quaternion.AngleAxis(0f, rotVector);
-        _zGizmoRoot.rotation = Quaternion.AngleAxis(0f, rotVector);
+        rotation = 0f;
+        ResetRotationLocalFrameAxis(rotVector);
       }
     }
     static void MatchPieceRotation(Piece target) {
@@ -277,13 +276,14 @@ namespace Gizmo {
     }
 
     static void ResetRotationsLocalFrame() {
-      _comfyGizmo.transform.rotation = Quaternion.AngleAxis(0f, Vector3.up);
-      _comfyGizmo.transform.rotation = Quaternion.AngleAxis(0f, Vector3.right);
-      _comfyGizmo.transform.rotation = Quaternion.AngleAxis(0f, Vector3.forward);
+      ResetRotationLocalFrameAxis(Vector3.up);
+      ResetRotationLocalFrameAxis(Vector3.right);
+      ResetRotationLocalFrameAxis(Vector3.forward);
+    }
 
-      _gizmoRoot.rotation = Quaternion.AngleAxis(0f, Vector3.up);
-      _gizmoRoot.rotation = Quaternion.AngleAxis(0f, Vector3.right);
-      _gizmoRoot.rotation = Quaternion.AngleAxis(0f, Vector3.forward);
+    static void ResetRotationLocalFrameAxis(Vector3 axis) {
+      _comfyGizmo.transform.rotation = Quaternion.AngleAxis(0f, axis);
+      _gizmoRoot.rotation = Quaternion.AngleAxis(0f, axis);
     }
 
     static GameObject LoadGizmoPrefab() {

--- a/Gizmo/Gizmo/ComfyGizmo.cs
+++ b/Gizmo/Gizmo/ComfyGizmo.cs
@@ -102,6 +102,20 @@ namespace Gizmo {
           return;
         }
 
+        if(Input.GetKeyDown(SnapDivisionIncrementKey.Value.MainKey)) {
+          if(SnapDivisions.Value * 2 <= MaxSnapDivisions) {
+            MessageHud.instance.ShowMessage(MessageHud.MessageType.TopLeft, $"Snap divisions increased to {SnapDivisions.Value * 2}");
+            SnapDivisions.Value = SnapDivisions.Value * 2;
+          }
+        }
+
+        if (Input.GetKeyDown(SnapDivisionDecrementKey.Value.MainKey)) {
+          if(Math.Floor(SnapDivisions.Value/2f) == SnapDivisions.Value/2f && SnapDivisions.Value/2 >= MinSnapDivisions) {
+            MessageHud.instance.ShowMessage(MessageHud.MessageType.TopLeft, $"Snap divisions decreased to {SnapDivisions.Value / 2}");
+            SnapDivisions.Value = SnapDivisions.Value / 2;
+          }
+        }
+
         if (Input.GetKey(CopyPieceRotationKey.Value.MainKey) && __instance.m_hoveringPiece != null) {
           MatchPieceRotation(__instance.m_hoveringPiece);
         }

--- a/Gizmo/Gizmo/ComfyGizmo.cs
+++ b/Gizmo/Gizmo/ComfyGizmo.cs
@@ -106,10 +106,11 @@ namespace Gizmo {
           MatchPieceRotation(__instance.m_hoveringPiece);
         }
 
-        // Reset rotations on changing from default rotations to local frame rotations and vice versa
+        // Change Rotation Frames
         if (Input.GetKeyDown(ChangeRotationModeKey.Value.MainKey)) {
           if(_localFrame) {
-            if(ResetRotation.Value) {
+            MessageHud.instance.ShowMessage(MessageHud.MessageType.TopLeft, "Default rotation mode enabled");
+            if (ResetRotation.Value) {
               ResetRotationsLocalFrame();
             } else {
               _eulerAngles = _comfyGizmo.transform.eulerAngles;
@@ -118,7 +119,8 @@ namespace Gizmo {
             }
             
           } else {
-            if(ResetRotation.Value) {
+            MessageHud.instance.ShowMessage(MessageHud.MessageType.TopLeft, "Local frame rotation mode enabled");
+            if (ResetRotation.Value) {
               ResetRotations();
             } else {
               Quaternion currentRotation = _comfyGizmoRoot.rotation;

--- a/Gizmo/Gizmo/ComfyGizmo.cs
+++ b/Gizmo/Gizmo/ComfyGizmo.cs
@@ -106,6 +106,14 @@ namespace Gizmo {
           if(SnapDivisions.Value * 2 <= MaxSnapDivisions) {
             MessageHud.instance.ShowMessage(MessageHud.MessageType.TopLeft, $"Snap divisions increased to {SnapDivisions.Value * 2}");
             SnapDivisions.Value = SnapDivisions.Value * 2;
+            if(ResetRotationOnSnapDivisionChange.Value) {
+              if(_localFrame) {
+                ResetRotationsLocalFrame();
+              } else {
+                ResetRotations();
+              }
+              return;
+            }
           }
         }
 
@@ -113,6 +121,14 @@ namespace Gizmo {
           if(Math.Floor(SnapDivisions.Value/2f) == SnapDivisions.Value/2f && SnapDivisions.Value/2 >= MinSnapDivisions) {
             MessageHud.instance.ShowMessage(MessageHud.MessageType.TopLeft, $"Snap divisions decreased to {SnapDivisions.Value / 2}");
             SnapDivisions.Value = SnapDivisions.Value / 2;
+            if (ResetRotationOnSnapDivisionChange.Value) {
+              if (_localFrame) {
+                ResetRotationsLocalFrame();
+              } else {
+                ResetRotations();
+              }
+              return;
+            }
           }
         }
 
@@ -238,6 +254,7 @@ namespace Gizmo {
       }
     }
     static void ResetRotations() {
+      _eulerAngles = Vector3.zero;
       _comfyGizmo.transform.localRotation = Quaternion.Euler(Vector3.zero);
       RotateGizmoComponents(Vector3.zero);
     }

--- a/Gizmo/Gizmo/ComfyGizmo.cs
+++ b/Gizmo/Gizmo/ComfyGizmo.cs
@@ -141,7 +141,7 @@ namespace Gizmo {
         if (Input.GetKeyDown(ChangeRotationModeKey.Value.MainKey)) {
           if(_localFrame) {
             MessageHud.instance.ShowMessage(MessageHud.MessageType.TopLeft, "Default rotation mode enabled");
-            if (ResetRotation.Value) {
+            if (ResetRotationOnModeChange.Value) {
               ResetRotationsLocalFrame();
             } else {
               _eulerAngles = _comfyGizmo.transform.eulerAngles;
@@ -151,7 +151,7 @@ namespace Gizmo {
             
           } else {
             MessageHud.instance.ShowMessage(MessageHud.MessageType.TopLeft, "Local frame rotation mode enabled");
-            if (ResetRotation.Value) {
+            if (ResetRotationOnModeChange.Value) {
               ResetRotations();
             } else {
               Quaternion currentRotation = _comfyGizmoRoot.rotation;

--- a/Gizmo/Gizmo/PluginConfig.cs
+++ b/Gizmo/Gizmo/PluginConfig.cs
@@ -16,7 +16,7 @@ namespace Gizmo {
     public static ConfigEntry<KeyboardShortcut> SnapDivisionDecrementKey;
 
     public static ConfigEntry<bool> ShowGizmoPrefab;
-    public static ConfigEntry<bool> ResetRotation;
+    public static ConfigEntry<bool> ResetRotationOnModeChange;
     public static ConfigEntry<bool> ResetRotationOnSnapDivisionChange;
 
     public static int MaxSnapDivisions = 256;
@@ -89,9 +89,10 @@ namespace Gizmo {
               new KeyboardShortcut(KeyCode.PageDown),
               "Doubles snap divisions from current.");
 
-      ResetRotationOnSnapDivisionChange = config.Bind("Snap Division Change", "resetOnSnapDivisionChange", true, "Resets the piece's rotation on snap division change.");
       ShowGizmoPrefab = config.Bind("UI", "showGizmoPrefab", true, "Show the Gizmo prefab in placement mode.");
-      ResetRotation = config.Bind("RotationFrame", "resetOnModeChange", true, "Resets the piece's rotation on mode switch.");
+
+      ResetRotationOnSnapDivisionChange = config.Bind("Reset", "resetOnSnapDivisionChange", true, "Resets the piece's rotation on snap division change.");
+      ResetRotationOnModeChange = config.Bind("Reset", "resetOnModeChange", true, "Resets the piece's rotation on mode switch.");
     }
   }
 }

--- a/Gizmo/Gizmo/PluginConfig.cs
+++ b/Gizmo/Gizmo/PluginConfig.cs
@@ -14,7 +14,7 @@ namespace Gizmo {
     public static ConfigEntry<KeyboardShortcut> CopyPieceRotationKey;
 
     public static ConfigEntry<bool> ShowGizmoPrefab;
-    public static ConfigEntry<bool> UseLocalFrame;
+    public static ConfigEntry<bool> ResetRotation;
 
     public static void BindConfig(ConfigFile config) {
       SnapDivisions =
@@ -70,7 +70,7 @@ namespace Gizmo {
               "Press this key to copy targeted piece's rotation.");
 
       ShowGizmoPrefab = config.Bind("UI", "showGizmoPrefab", true, "Show the Gizmo prefab in placement mode.");
-      UseLocalFrame = config.Bind("RotationFrame", "useLocalFrame", false, "Use the local piece coordinate system for rotations.");
+      ResetRotation = config.Bind("RotationFrame", "resetOnModeChange", true, "Resets the piece's rotation on mode switch.");
     }
   }
 }

--- a/Gizmo/Gizmo/PluginConfig.cs
+++ b/Gizmo/Gizmo/PluginConfig.cs
@@ -12,9 +12,14 @@ namespace Gizmo {
     public static ConfigEntry<KeyboardShortcut> ResetAllRotationKey;
     public static ConfigEntry<KeyboardShortcut> ChangeRotationModeKey;
     public static ConfigEntry<KeyboardShortcut> CopyPieceRotationKey;
+    public static ConfigEntry<KeyboardShortcut> SnapDivisionIncrementKey;
+    public static ConfigEntry<KeyboardShortcut> SnapDivisionDecrementKey;
 
     public static ConfigEntry<bool> ShowGizmoPrefab;
     public static ConfigEntry<bool> ResetRotation;
+
+    public static int MaxSnapDivisions = 256;
+    public static int MinSnapDivisions = 2;
 
     public static void BindConfig(ConfigFile config) {
       SnapDivisions =
@@ -24,7 +29,7 @@ namespace Gizmo {
               16,
               new ConfigDescription(
                   "Number of snap angles per 180 degrees. Vanilla uses 8.",
-                 new AcceptableValueRange<int>(2, 256)));
+                 new AcceptableValueRange<int>(MinSnapDivisions, MaxSnapDivisions)));
 
       XRotationKey =
           config.Bind(
@@ -68,6 +73,20 @@ namespace Gizmo {
               "copyPieceRotation",
               KeyboardShortcut.Empty,
               "Press this key to copy targeted piece's rotation.");
+
+      SnapDivisionIncrementKey =
+          config.Bind(
+              "Keys",
+              "snapDivisionIncrement",
+              new KeyboardShortcut(KeyCode.PageUp),
+              "Doubles snap divisions from current.");
+
+      SnapDivisionDecrementKey =
+          config.Bind(
+              "Keys",
+              "snapDivisionDecrement",
+              new KeyboardShortcut(KeyCode.PageDown),
+              "Doubles snap divisions from current.");
 
       ShowGizmoPrefab = config.Bind("UI", "showGizmoPrefab", true, "Show the Gizmo prefab in placement mode.");
       ResetRotation = config.Bind("RotationFrame", "resetOnModeChange", true, "Resets the piece's rotation on mode switch.");

--- a/Gizmo/Gizmo/PluginConfig.cs
+++ b/Gizmo/Gizmo/PluginConfig.cs
@@ -17,6 +17,7 @@ namespace Gizmo {
 
     public static ConfigEntry<bool> ShowGizmoPrefab;
     public static ConfigEntry<bool> ResetRotation;
+    public static ConfigEntry<bool> ResetRotationOnSnapDivisionChange;
 
     public static int MaxSnapDivisions = 256;
     public static int MinSnapDivisions = 2;
@@ -88,6 +89,7 @@ namespace Gizmo {
               new KeyboardShortcut(KeyCode.PageDown),
               "Doubles snap divisions from current.");
 
+      ResetRotationOnSnapDivisionChange = config.Bind("Snap Division Change", "resetOnSnapDivisionChange", true, "Resets the piece's rotation on snap division change.");
       ShowGizmoPrefab = config.Bind("UI", "showGizmoPrefab", true, "Show the Gizmo prefab in placement mode.");
       ResetRotation = config.Bind("RotationFrame", "resetOnModeChange", true, "Resets the piece's rotation on mode switch.");
     }

--- a/Gizmo/Gizmo/README.md
+++ b/Gizmo/Gizmo/README.md
@@ -27,9 +27,13 @@
 ## Changelog
 
 ### 1.5.0
+  * Added hotkeys for halving and doubling snap divisions. PageUp and PageDown by default.
+  * Added toggle for resetting piece rotation on snap division change. Enabled by default.
+  * Added feature to copy target piece's rotation.
   * Added alternate rotation method for using local frame coordinates.
   * Added configuration option to rotate using local frame coordinates.
   * Hot key added to toggle between default and local frame rotation modes. Default set to back quote.
+  * Added toggle to reset piece orientation which changing between rotation frames. Enabled by default.
   
 ### 1.4.0
 


### PR DESCRIPTION
Various bug fixes and additional features added for v1.5.0 release:
- Ability to copy target pieces rotation
- Ability to toggle off resetting rotation on frame change
- Ability to half/double snap points via hotkeys
- Ability to toggle off resetting rotation on snap point division changes